### PR TITLE
Update make-dir dependency to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"windows"
 	],
 	"dependencies": {
-		"make-dir": "^3.1.0",
+		"make-dir": "^4.0.0",
 		"meow": "^10.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
make-dir 3.1.0 -> 4.0.0 to get updated semver dependency

make-dir v4.0.0 was major release due to dropped support for node 8, but make-dir-cli already requires node >=12.17 so not major release for this package